### PR TITLE
Using "Error instanceof ParseError", returns a result you don't want after typescript 2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
     "coverage": "nyc ava --verbose",
     "build": "tsc --build tsconfig-build.json"
   },
-  "dependencies": {
-    "make-error": "^1.3.6"
-  },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/node": "^14.11.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "coverage": "nyc ava --verbose",
     "build": "tsc --build tsconfig-build.json"
   },
+  "dependencies": {
+    "make-error": "^1.3.6"
+  },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/node": "^14.11.8",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "typedoc": "^0.20.0",
     "typescript": "^4.1.3"
   },
+  "dependencies": {
+    "make-error": "^1.3.6"
+  },
   "ava": {
     "extensions": [
       "ts"

--- a/src/parse-chunk/hunting-session-header.ts
+++ b/src/parse-chunk/hunting-session-header.ts
@@ -65,14 +65,14 @@ const parseHuntingSessionHeader = function <
 
   const pattern = [
     `^XP Gain: (${patterns.integer})`,
-    `XP/h: (${patterns.integer})`,
+    `XP\/h: (${patterns.integer})`,
     `Loot: (${patterns.integer})`,
     `Supplies: (${patterns.integer})`,
     `Balance: (${patterns.integer})`,
     `Damage: (${patterns.integer})`,
-    `Damage/h: (${patterns.integer})`,
+    `Damage\/h: (${patterns.integer})`,
     `Healing: (${patterns.integer})`,
-    `Healing/h: (${patterns.integer})`,
+    `Healing\/h: (${patterns.integer})`,
     ''
   ].join(lineBreakPattern);
 

--- a/src/parse-chunk/monster-count.ts
+++ b/src/parse-chunk/monster-count.ts
@@ -59,7 +59,7 @@ const parseMonsterCount = function <
 
   const pattern = [
     `^(${patterns.count}) (${patterns.monsterName})`,
-    `(${indentationPattern}?)`
+    `(${indentationPattern})?`
   ].join(lineBreakPattern);
 
   const matched = new RegExp(pattern).exec(content);

--- a/src/parse-error.ts
+++ b/src/parse-error.ts
@@ -1,4 +1,5 @@
+import { BaseError } from "make-error";
 
-export class ParseError extends Error {
+export class ParseError extends BaseError {
   name = 'ParseError';
 }

--- a/src/parse-error.ts
+++ b/src/parse-error.ts
@@ -1,5 +1,4 @@
-import { BaseError } from "make-error";
 
-export class ParseError extends BaseError {
+export class ParseError extends Error {
   name = 'ParseError';
 }


### PR DESCRIPTION
Using "Error instanceof ParseError", returns a result you don't want, after typescript 2.1

I believe it is better to use a ready-made library for this purpose, rather than trying to invent it :)

`"make-error": "^1.3.6"`