### PR TITLE
Bug fixes for newer versions of typescript and others (Regex error, ParserError, Bug extends Error,...)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "typedoc": "^0.20.0",
     "typescript": "^4.1.3"
   },
+  "dependencies": {
+    "make-error": "^1.3.6"
+  },
   "ava": {
     "extensions": [
       "ts"

--- a/src/parse-chunk/hunting-session-header.ts
+++ b/src/parse-chunk/hunting-session-header.ts
@@ -65,14 +65,14 @@ const parseHuntingSessionHeader = function <
 
   const pattern = [
     `^XP Gain: (${patterns.integer})`,
-    `XP/h: (${patterns.integer})`,
+    `XP\/h: (${patterns.integer})`,
     `Loot: (${patterns.integer})`,
     `Supplies: (${patterns.integer})`,
     `Balance: (${patterns.integer})`,
     `Damage: (${patterns.integer})`,
-    `Damage/h: (${patterns.integer})`,
+    `Damage\/h: (${patterns.integer})`,
     `Healing: (${patterns.integer})`,
-    `Healing/h: (${patterns.integer})`,
+    `Healing\/h: (${patterns.integer})`,
     ''
   ].join(lineBreakPattern);
 

--- a/src/parse-chunk/monster-count.ts
+++ b/src/parse-chunk/monster-count.ts
@@ -59,7 +59,7 @@ const parseMonsterCount = function <
 
   const pattern = [
     `^(${patterns.count}) (${patterns.monsterName})`,
-    `(${indentationPattern}?)`
+    `(${indentationPattern})?`
   ].join(lineBreakPattern);
 
   const matched = new RegExp(pattern).exec(content);

--- a/src/parse-error.ts
+++ b/src/parse-error.ts
@@ -1,4 +1,5 @@
+import { BaseError } from "make-error"
 
-export class ParseError extends Error {
+export class ParseError extends BaseError {
   name = 'ParseError';
 }

--- a/src/parse-error.ts
+++ b/src/parse-error.ts
@@ -1,4 +1,4 @@
-import { BaseError } from "make-error"
+import { BaseError } from "make-error";
 
 export class ParseError extends BaseError {
   name = 'ParseError';


### PR DESCRIPTION
`#1 
**Bug:**
> There lack of escaping was causing "ParseHuntingSessionHeaderError", after escaping the forward slash, everything worked fine.

**Fix:**
> I added escaping this "/" to "\/" in the pattern, because it was causing "ParseHuntingSessionHeaderError"

this
```
  const pattern = [
    `^XP Gain: (${patterns.integer})`,
    `XP/h: (${patterns.integer})`,
    `Loot: (${patterns.integer})`,
    `Supplies: (${patterns.integer})`,
    `Balance: (${patterns.integer})`,
    `Damage: (${patterns.integer})`,
    `Damage/h: (${patterns.integer})`,
    `Healing: (${patterns.integer})`,
    `Healing/h: (${patterns.integer})`,
    ''
  ].join(lineBreakPattern);
```
for this
```
  const pattern = [
    `^XP Gain: (${patterns.integer})`,
    `XP\/h: (${patterns.integer})`,
    `Loot: (${patterns.integer})`,
    `Supplies: (${patterns.integer})`,
    `Balance: (${patterns.integer})`,
    `Damage: (${patterns.integer})`,
    `Damage\/h: (${patterns.integer})`,
    `Healing: (${patterns.integer})`,
    `Healing\/h: (${patterns.integer})`,
    ''
  ].join(lineBreakPattern);
```

#2 
Bug:
>  In some situations causing "ParseMonsterCountHeaderError", simply changing the location of the "?"(optional) outside the group, everything worked fine again.

**Fix:**
> Pattern with "?" inside the group "( ?)" causing "ParseMonsterCountHeaderError", correcting to "( )?". Everything went well.

this
```
 const pattern = [
    `^(${patterns.count}) (${patterns.monsterName})`,
    `(${indentationPattern}?)`
  ].join(lineBreakPattern);
```
for this
```
 const pattern = [
    `^(${patterns.count}) (${patterns.monsterName})`,
    `(${indentationPattern})?`
  ].join(lineBreakPattern);
```

#3 
**Bug:** 
> Using "Error instanceof ParseError", returns a result you don't want, after typescript 2.1

**Fix:** 
>  I believe it is better to use a ready-made library for this purpose, rather than trying to invent it :)

 add package.json
`"make-error": "^1.3.6"`
and modify
```
import { BaseError } from "make-error"

export class ParseError extends BaseError {
  name = 'ParseError';
}
```